### PR TITLE
Priorities fix

### DIFF
--- a/pushpipe
+++ b/pushpipe
@@ -63,9 +63,9 @@ def message(token, user, WORDS, DEV, TITLE, URL, UTITLE, PRIORITY):
 	if PRIORITY is None:
 		PRI2=0
 	elif PRIORITY is not None:
-		if (PRIORITY == "High" or "high" or "Hi" or "HI" or "hi" or "H" or "h"):
+		if (PRIORITY in ["High","high","Hi","HI","hi","H","h"]):
 			PRI2=1
-		elif (PRIORITY == "Low" or "low" or "Lo" or "LO" or "lo" or "L" or "l"):
+		elif (PRIORITY in ["Low","low","Lo","LO","lo","L","l"]):
 			PRI2=-1
 		else:
 			PRI2=0


### PR DESCRIPTION
Hey Brian, there was a small bug in your pushpipe that broke push priorities, Any priority specified always resulted in a high priority being assigned to the notification. If no priority was specified, the notification was sent with normal priority (as expected).
